### PR TITLE
Refine hero motion stage

### DIFF
--- a/src/components/HelloMotion.vue
+++ b/src/components/HelloMotion.vue
@@ -1,62 +1,118 @@
 <template>
   <section class="hero">
     <div class="hero__text">
-      <h1 class="h1">Rectangles That Rules Numbers</h1>
+      <p class="eyebrow">Product UX Designer</p>
+      <h1 class="h1">Rectangles that Listen to Every User Signal</h1>
       <p class="body1">
-        This is story of me and how UX can change things around us. Something else
-        to write here.
+        I design motion-rich interfaces where every micro-interaction is backed by
+        research. These are the four rituals that keep my UX practice sharp and
+        human.
       </p>
     </div>
 
     <div class="hero__stage">
-      <ul
-        class="motion-list"
-        layout
-        :transition="{
-          layout: { type: 'spring', stiffness: 20, damping: 4, mass: 0.1 },
-        }"
-      >
+      <svg class="hero__defs" aria-hidden="true">
+        <defs>
+          <filter
+            v-for="(block, idx) in blocks"
+            :key="`filter-${idx}`"
+            :id="`liquid-glow-${idx}`"
+            x="-60%"
+            y="-60%"
+            width="220%"
+            height="220%"
+            color-interpolation-filters="sRGB"
+          >
+            <feTurbulence
+              type="fractalNoise"
+              baseFrequency="0.85"
+              numOctaves="2"
+              :seed="idx * 12 + 5"
+              result="noise"
+            />
+            <feGaussianBlur in="noise" stdDeviation="6" result="softNoise" />
+            <feDisplacementMap
+              in="SourceGraphic"
+              in2="softNoise"
+              scale="18"
+              xChannelSelector="R"
+              yChannelSelector="B"
+              result="distortion"
+            />
+            <feGaussianBlur in="distortion" stdDeviation="10" result="blurred" />
+            <feFlood :flood-color="block.glow" flood-opacity="0.85" result="flood" />
+            <feComposite in="flood" in2="blurred" operator="in" result="glow" />
+            <feBlend in="distortion" in2="glow" mode="screen" />
+          </filter>
+        </defs>
+      </svg>
+
+      <ul class="motion-list" layout :transition="listTransition">
         <motion.li
           v-for="(block, idx) in blocks"
-          :key="idx"
+          :key="block.number"
           layout
           :custom="idx"
           :variants="boxVariants"
-          :animate="block.isActive ? 'active' : hovered[idx] ? 'hover' : 'default'"
+          :animate="getState(idx)"
           :transition="getLayoutSpring(idx)"
           initial="default"
           class="motion-square"
-          @mouseenter="hovered[idx] = true"
-          @mouseleave="hovered[idx] = false"
+          :class="{ 'is-hovered': hovered[idx], 'is-active': block.isActive }"
+          @mouseenter="onHover(idx, true)"
+          @mouseleave="onHover(idx, false)"
           @click="toggleState(idx)"
+          :style="getSquareStyle(block, idx)"
           :data-state="block.isActive"
         >
-          <!-- Вращаем ТОЛЬКО SVG -->
           <motion.svg
+            class="motion-square__svg"
             width="100%"
             height="100%"
             viewBox="0 0 100 100"
             :variants="svgVariants"
-            :animate="
-              block.isActive ? 'active' : hovered[idx] ? 'hover' : 'default'
-            "
+            :animate="getState(idx)"
             :transition="spring"
             style="transform-origin: 50% 50%; display: block"
           >
-            <!-- rect вместо polygon; скругления пропорциональны (во viewBox ед.) -->
-            <rect
+            <motion.rect
               x="0"
               y="0"
               width="100"
               height="100"
               :rx="cornerRadius"
               :ry="cornerRadius"
-              fill="var(--color-square-fill)"
+              stroke-width="1.2"
+              :style="{
+                fill: block.isActive
+                  ? block.active
+                  : hovered[idx]
+                  ? block.hover
+                  : 'var(--color-square-default)',
+                stroke: 'var(--color-square-outline)',
+                filter: hovered[idx] ? `url(#liquid-glow-${idx})` : 'none',
+              }"
             />
           </motion.svg>
 
-          <!-- Контент поверх, НЕ вращается -->
-          <div class="motion-content">{{ idx + 1 }}</div>
+          <div
+            class="motion-liquid"
+            :style="{
+              filter: hovered[idx] ? `url(#liquid-glow-${idx})` : 'none',
+              background: hovered[idx] ? block.glass : 'transparent',
+            }"
+          ></div>
+
+          <div class="motion-content">
+            <span class="motion-number">{{ block.number }}</span>
+            <Transition name="fade">
+              <article v-if="block.isActive" class="fact-card">
+                <p class="caption fact-card__tag">{{ block.tag }}</p>
+                <h2 class="h3 fact-card__title">{{ block.title }}</h2>
+                <p class="body2 fact-card__text">{{ block.description }}</p>
+              </article>
+            </Transition>
+          </div>
         </motion.li>
       </ul>
     </div>
@@ -67,82 +123,137 @@
 import { motion } from "motion-v";
 import { reactive, ref } from "vue";
 
-/** Несколько активных можно одновременно */
-const blocks = reactive(Array.from({ length: 4 }, () => ({ isActive: false })));
-const hovered = reactive(Array.from({ length: 4 }, () => false));
+const baseBlocks = [
+  {
+    number: "01",
+    tag: "User Research",
+    title: "Empathy Maps Draw the First Wireframe",
+    description:
+      "Interviews, journey maps and diaries help me understand the emotional cadence of every task before I design a single pixel.",
+    hover: "var(--color-accent-1)",
+    active: "var(--color-accent-1-strong)",
+    glow: "var(--color-accent-1-glow)",
+    glass: "rgba(74, 169, 255, 0.18)",
+  },
+  {
+    number: "02",
+    tag: "Rapid Experimentation",
+    title: "Prototypes Answer Questions in Days",
+    description:
+      "Clickable flows in Figma and code sandboxes let teams watch real people interact, so we ship the confident option—not the loudest opinion.",
+    hover: "var(--color-accent-2)",
+    active: "var(--color-accent-2-strong)",
+    glow: "var(--color-accent-2-glow)",
+    glass: "rgba(255, 126, 182, 0.18)",
+  },
+  {
+    number: "03",
+    tag: "Product Narrative",
+    title: "Microcopy Coaches Without Speaking",
+    description:
+      "I craft interface language that celebrates success states and softens edge cases so guidance feels like a teammate, not a tooltip.",
+    hover: "var(--color-accent-3)",
+    active: "var(--color-accent-3-strong)",
+    glow: "var(--color-accent-3-glow)",
+    glass: "rgba(127, 246, 166, 0.18)",
+  },
+  {
+    number: "04",
+    tag: "Metrics & Iteration",
+    title: "Dashboards Fuel Weekly Decisions",
+    description:
+      "North-star metrics sit next to qualitative notes so every iteration connects data, empathy and motion patterns the team can trust.",
+    hover: "var(--color-accent-4)",
+    active: "var(--color-accent-4-strong)",
+    glow: "var(--color-accent-4-glow)",
+    glass: "rgba(255, 215, 111, 0.18)",
+  },
+];
+
+const blocks = reactive(baseBlocks.map((item) => ({ ...item, isActive: false })));
+const hovered = reactive(Array.from({ length: blocks.length }, () => false));
 const lastToggledIdx = ref(-1);
 
-/** Пружина (как было) */
-const spring = { type: "spring", stiffness: 20, damping: 4, mass: 0.1 };
+const spring = { type: "spring", stiffness: 24, damping: 6, mass: 0.18 };
+const listTransition = { layout: { type: "spring", stiffness: 28, damping: 6, mass: 0.18 } };
 
-/** ТВОИ ЖЕ boxVariants — без изменений */
 const boxVariants = {
   default: {
-    width: 120,
-    height: 120,
+    width: 132,
+    height: 132,
     marginLeft: 0,
     marginRight: 0,
     y: 0,
     transition: spring,
   },
   hover: {
-    width: 150,
-    height: 150,
-    marginLeft: 10, // фиксированный отступ
-    marginRight: 10, // фиксированный отступ
+    width: 168,
+    height: 168,
+    marginLeft: 16,
+    marginRight: 16,
     transition: spring,
   },
   active: (i) => ({
-    width: 600,
-    height: 600,
-    marginLeft: 10, // ещё больше отступ
-    marginRight: 10, // ещё больше отступ
-    y: i % 2 === 0 ? "33%" : "-33%",
+    width: 480,
+    height: 480,
+    marginLeft: 18,
+    marginRight: 18,
+    y: i % 2 === 0 ? "-20%" : "20%",
     transition: spring,
   }),
 };
 
-/** Поворот ромбом */
 const svgVariants = {
   default: { rotate: 0 },
   hover: { rotate: 45 },
   active: { rotate: 45 },
 };
 
-const cornerRadius = 10; // во viewBox-единицах (масштабируется пропорционально)
+const cornerRadius = 18;
 
 function toggleState(idx) {
-  blocks[idx].isActive = !blocks[idx].isActive; // НЕ закрываем другие
+  blocks[idx].isActive = !blocks[idx].isActive;
   lastToggledIdx.value = idx;
 }
 
+function onHover(idx, value) {
+  hovered[idx] = value;
+}
+
+function getState(idx) {
+  return blocks[idx].isActive ? "active" : hovered[idx] ? "hover" : "default";
+}
+
 function getLayoutSpring(idx) {
-  const d =
+  const distance =
     lastToggledIdx.value === -1 ? 0 : Math.abs(idx - lastToggledIdx.value);
-  return { ...spring, delay: d * 0.5 };
+  return { ...spring, delay: distance * 0.45 };
+}
+
+function getSquareStyle(block, idx) {
+  return {
+    '--square-glow': block.glow,
+    '--square-accent': block.active,
+    zIndex: blocks[idx].isActive ? 30 : hovered[idx] ? 20 : 10,
+  };
 }
 </script>
 
 <style scoped>
 .hero {
   position: relative;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  align-content: center;
-  justify-items: start;
   width: 100%;
-  max-width: 1040px;
+  max-width: 1280px;
   min-height: 100vh;
-  padding-block: clamp(48px, 12vh, 96px);
-  padding-inline-start: clamp(32px, 12vw, 120px);
-  padding-inline-end: clamp(24px, 6vw, 96px);
-  box-sizing: border-box;
-  overflow: visible;
+  margin: 0 auto;
+  padding-block: clamp(72px, 14vh, 144px);
+  padding-inline: clamp(24px, 6vw, 88px);
+  display: grid;
+  align-content: center;
 }
 
 .hero__text {
-  grid-area: 1 / 1;
-  max-width: 720px;
+  max-width: 560px;
   display: grid;
   gap: 24px;
   position: relative;
@@ -150,19 +261,27 @@ function getLayoutSpring(idx) {
 }
 
 .hero__stage {
-  grid-area: 1 / 1;
-  align-self: stretch;
-  justify-self: stretch;
-  padding-top: clamp(120px, 22vh, 260px);
-  position: relative;
-  z-index: 2;
+  position: absolute;
+  top: 50%;
+  right: clamp(32px, 10vw, 168px);
+  transform: translateY(-50%);
+  width: min(65vw, 640px);
   pointer-events: none;
+  z-index: 2;
+}
+
+.hero__defs {
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
 }
 
 .motion-list {
   display: flex;
-  gap: clamp(12px, 2vw, 20px);
   align-items: center;
+  justify-content: flex-end;
+  gap: clamp(14px, 2vw, 28px);
   margin: 0;
   padding: 0;
   list-style: none;
@@ -170,38 +289,163 @@ function getLayoutSpring(idx) {
 }
 
 .motion-square {
-  position: relative; /* для контента поверх */
-  width: 120px; /* фолбэк до инициализации Motion */
-  height: 120px;
-  background: transparent;
+  position: relative;
+  width: 132px;
+  height: 132px;
   list-style: none;
-  box-sizing: border-box;
   cursor: pointer;
+  overflow: visible;
+  user-select: none;
+}
+
+.motion-square__svg {
+  position: absolute;
+  inset: 0;
+  overflow: visible;
+}
+
+.motion-square:is(.is-hovered, .is-active) .motion-square__svg {
+  filter: drop-shadow(0 20px 60px rgba(0, 0, 0, 0.25));
+}
+
+.motion-liquid {
+  position: absolute;
+  inset: 12%;
+  border-radius: 32px;
+  transform: rotate(45deg);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.45s ease, backdrop-filter 0.45s ease;
+  backdrop-filter: blur(0px);
+  mix-blend-mode: screen;
+}
+
+.motion-square.is-hovered .motion-liquid {
+  opacity: 1;
+  backdrop-filter: blur(22px);
 }
 
 .motion-content {
   position: absolute;
   inset: 0;
   display: grid;
-  place-items: center;
-  color: var(--color-square-content);
-  font-weight: 800;
-  font-size: 18px;
-  line-height: 1;
-  user-select: none;
-  pointer-events: none; /* клики идут в li */
+  align-content: center;
+  justify-items: center;
+  gap: 20px;
+  padding: clamp(24px, 4vw, 60px);
+  text-align: center;
+  pointer-events: none;
 }
 
-@media (max-width: 768px) {
+.motion-number {
+  font-family: var(--font-family-base);
+  font-weight: 700;
+  font-size: clamp(28px, 3.6vw, 44px);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-tertiary);
+  text-shadow: 0 0 0 transparent;
+  transition: color 0.3s ease, text-shadow 0.3s ease, opacity 0.3s ease,
+    transform 0.3s ease;
+}
+
+.motion-square.is-hovered .motion-number {
+  color: var(--square-accent);
+  text-shadow: 0 0 34px var(--square-glow);
+}
+
+.motion-square.is-active .motion-number {
+  opacity: 0;
+  transform: translateY(-12px);
+}
+
+.fact-card {
+  display: grid;
+  gap: 16px;
+  padding: clamp(24px, 4vw, 48px);
+  background: rgba(15, 16, 20, 0.55);
+  border-radius: 32px;
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(16px);
+  border: 1px solid rgba(244, 246, 248, 0.06);
+  text-align: left;
+}
+
+.fact-card__tag {
+  color: var(--color-text-tertiary);
+}
+
+.fact-card__title {
+  color: var(--color-text-primary);
+}
+
+.fact-card__text {
+  color: var(--color-text-secondary);
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.32s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+
+@media (max-width: 1200px) {
+  .hero__stage {
+    right: clamp(24px, 8vw, 120px);
+    width: min(68vw, 560px);
+  }
+
+  .motion-list {
+    gap: clamp(12px, 1.6vw, 20px);
+  }
+}
+
+@media (max-width: 1024px) {
   .hero {
-    min-height: auto;
-    padding-block: clamp(40px, 12vh, 72px);
-    padding-inline-start: clamp(24px, 16vw, 72px);
-    padding-inline-end: clamp(16px, 8vw, 48px);
+    padding-inline: clamp(24px, 8vw, 64px);
   }
 
   .hero__stage {
-    padding-top: clamp(96px, 24vh, 200px);
+    position: relative;
+    top: auto;
+    right: auto;
+    transform: none;
+    margin-top: clamp(56px, 10vh, 96px);
+    width: 100%;
+  }
+
+  .motion-list {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 720px) {
+  .hero {
+    padding-block: clamp(56px, 18vh, 104px);
+  }
+
+  .motion-content {
+    padding: clamp(24px, 10vw, 40px);
+  }
+
+  .fact-card {
+    padding: clamp(24px, 10vw, 40px);
+  }
+}
+
+@media (max-width: 560px) {
+  .motion-list {
+    gap: 12px;
+  }
+
+  .motion-square {
+    width: 112px;
+    height: 112px;
   }
 }
 </style>

--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,10 @@
 /* Global baseline styling */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
   font-family: var(
@@ -9,20 +15,22 @@ body {
     "Segoe UI",
     sans-serif
   );
-  background: radial-gradient(
-    circle at top left,
-    var(--color-bg-1),
-    var(--color-bg-2) 60%,
-    var(--color-bg-3) 100%
-  );
+  background-color: var(--color-bg-main);
   color: var(--color-text-primary);
   min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
 #app {
   width: 100%;
   min-height: 100vh;
   display: flex;
-  align-items: center;
-  justify-content: flex-start;
+  align-items: stretch;
+  justify-content: center;
+}
+
+img {
+  display: block;
+  max-width: 100%;
 }

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -1,9 +1,28 @@
 :root {
-  --color-text-primary: #ffffff;
-  --color-text-secondary: rgba(255, 255, 255, 0.8);
-  --color-bg-1: #1b1b1d;
-  --color-bg-2: #0d0d0f;
-  --color-bg-3: #050506;
-  --color-square-fill: #111111;
-  --color-square-content: var(--color-text-primary);
+  --color-bg-main: #0f1014;
+  --color-surface-dim: #14161c;
+  --color-surface-raised: #1b1e27;
+
+  --color-text-primary: #f4f6f8;
+  --color-text-secondary: rgba(244, 246, 248, 0.72);
+  --color-text-tertiary: rgba(244, 246, 248, 0.56);
+
+  --color-square-default: rgba(244, 246, 248, 0.06);
+  --color-square-outline: rgba(244, 246, 248, 0.08);
+
+  --color-accent-1: #4aa9ff;
+  --color-accent-1-strong: #62c4ff;
+  --color-accent-1-glow: rgba(74, 169, 255, 0.65);
+
+  --color-accent-2: #ff7eb6;
+  --color-accent-2-strong: #ff99c6;
+  --color-accent-2-glow: rgba(255, 126, 182, 0.6);
+
+  --color-accent-3: #7ff6a6;
+  --color-accent-3-strong: #9dffbd;
+  --color-accent-3-glow: rgba(127, 246, 166, 0.6);
+
+  --color-accent-4: #ffd76f;
+  --color-accent-4-strong: #ffe59b;
+  --color-accent-4-glow: rgba(255, 215, 111, 0.58);
 }

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 
 :root {
   --font-family-base: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
@@ -6,9 +6,10 @@
 
 .h1 {
   font-family: var(--font-family-base);
-  font-weight: 500;
-  font-size: 64px;
-  line-height: 77px;
+  font-weight: 600;
+  font-size: clamp(48px, 6vw, 72px);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
   color: var(--color-text-primary);
   margin: 0;
 }
@@ -16,8 +17,47 @@
 .body1 {
   font-family: var(--font-family-base);
   font-weight: 400;
-  font-size: 32px;
-  line-height: 46px;
+  font-size: clamp(18px, 2.2vw, 24px);
+  line-height: 1.6;
   color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.eyebrow {
+  font-family: var(--font-family-base);
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+  margin: 0 0 12px;
+}
+
+.h3 {
+  font-family: var(--font-family-base);
+  font-weight: 600;
+  font-size: clamp(28px, 3.2vw, 36px);
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.body2 {
+  font-family: var(--font-family-base);
+  font-weight: 400;
+  font-size: clamp(16px, 2vw, 20px);
+  line-height: 1.6;
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.caption {
+  font-family: var(--font-family-base);
+  font-weight: 600;
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
   margin: 0;
 }


### PR DESCRIPTION
## Summary
- redesign the hero layout so the UX intro copy stays fixed while the motion stage animates above it, adding SVG-based liquid glows and active cards for each fact
- populate each block with UX-designer themed content and ensure hover/active states carry unique accent colors with backdrop highlights
- refresh the shared color palette, typography scale, and base page styling for a flat dark background and polished details

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca25eea6d0832b9c3835ecbb704a01